### PR TITLE
Canon MakerNote: Allow callable to process tag value

### DIFF
--- a/exifread/classes.py
+++ b/exifread/classes.py
@@ -542,7 +542,10 @@ class ExifHeader:
             tag = mn_tags.get(i, ('Unknown', ))
             name = tag[0]
             if len(tag) > 1:
-                val = tag[1].get(value[i], 'Unknown')
+                if callable(tag[1]):
+                    val = tag[1](value[i])
+                else:
+                    val = tag[1].get(value[i], 'Unknown')
             else:
                 val = value[i]
             try:

--- a/exifread/tags/makernote/canon.py
+++ b/exifread/tags/makernote/canon.py
@@ -4,6 +4,17 @@ Makernote (proprietary) tag definitions for Canon.
 http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Canon.html
 """
 
+def add_one(value):
+    return value + 1
+
+
+def subtract_one(value):
+    return value - 1
+
+
+def convert_temp(value):
+    return '%d C' % (value - 128)
+
 TAGS = {
     0x0003: ('FlashInfo',),
     0x0006: ('ImageType', ),
@@ -538,6 +549,7 @@ SHOT_INFO = {
         3: 'None'
     }),
     9: ('SequenceNumber', ),
+    12: ('CameraTemperature', convert_temp),
     14: ('AFPointUsed', ),
     15: ('FlashBias', {
         0xFFC0: '-2 EV',
@@ -658,17 +670,6 @@ FILE_INFO = {
     })
 }
 
-
-def add_one(value):
-    return value + 1
-
-
-def subtract_one(value):
-    return value - 1
-
-
-def convert_temp(value):
-    return '%d C' % (value - 128)
 
 # CameraInfo data structures have variable sized members. Each entry here is:
 # byte offset: (item name, data item type, decoding map).


### PR DESCRIPTION
While working on some images I found that the library did not expose the 'CameraTemperature' tag from the ShotInfo MakerNote.

To support this I added a callable and allow that callable to be called with the tag value. I might be useful for other tags too.

Example output from a JPEG image taken on a Canon EOS 2000D:
```
>>> exif = exifread.process_file(fd, details=True)
>>> exif["MakerNote CameraTemperature"]
(0x0000) Proprietary=55 C @ 0
```